### PR TITLE
Add sample API controller and Svelte pages

### DIFF
--- a/Api/Controllers/GamesController.cs
+++ b/Api/Controllers/GamesController.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+using community.Services;
+
+namespace community.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class GamesController : ControllerBase
+{
+    private readonly GameService _gameService;
+
+    public GamesController(GameService gameService)
+    {
+        _gameService = gameService;
+    }
+
+    [HttpGet]
+    public IActionResult GetGames()
+    {
+        var (games, _) = _gameService.GetGames();
+        return Ok(games);
+    }
+
+    [HttpGet("{id}")]
+    public IActionResult GetGameById(long id)
+    {
+        var game = _gameService.GetGameById(id);
+        if (game == null)
+        {
+            return NotFound();
+        }
+        return Ok(game);
+    }
+
+    [HttpGet("{id}/score")]
+    public IActionResult GetScore(long id)
+    {
+        var score = _gameService.GetScoreByGameId(id);
+        return Ok(score);
+    }
+}

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -10,6 +10,8 @@ builder.Services.AddDbContextFactory<ApplicationDbContext>(options =>
 
 builder.Services.AddSingleton<GameService>();
 
+builder.Services.AddControllers();
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -18,10 +20,7 @@ var app = builder.Build();
 app.UseSwagger();
 app.UseSwaggerUI();
 
-app.MapGet("/api/games", (GameService gameService) =>
-{
-    var (games, _) = gameService.GetGames();
-    return Results.Ok(games);
-});
+
+app.MapControllers();
 
 app.Run();

--- a/svelte-frontend/src/App.svelte
+++ b/svelte-frontend/src/App.svelte
@@ -1,19 +1,33 @@
 <script>
-  let games = [];
+  import GameList from './pages/GameList.svelte';
+  import GameDetails from './pages/GameDetails.svelte';
 
-  async function loadGames() {
-    const res = await fetch('/api/games');
-    games = await res.json();
+  let currentPath = window.location.pathname;
+  let gameId = null;
+
+  function navigate(path) {
+    currentPath = path;
+    history.pushState({}, '', path);
   }
 
-  loadGames();
+  window.addEventListener('popstate', () => {
+    currentPath = window.location.pathname;
+  });
+  function parsePath(path) {
+    const match = path.match(/^\/game\/(\d+)/);
+    if (match) {
+      gameId = match[1];
+      return 'details';
+    }
+    gameId = null;
+    return 'list';
+  }
+
+  $: page = parsePath(currentPath);
 </script>
 
-<main>
-  <h1>Game List</h1>
-  <ul>
-    {#each games as game}
-      <li>{game.title}</li>
-    {/each}
-  </ul>
-</main>
+{#if page === 'list'}
+  <GameList />
+{:else if page === 'details'}
+  <GameDetails {gameId} />
+{/if}

--- a/svelte-frontend/src/pages/GameDetails.svelte
+++ b/svelte-frontend/src/pages/GameDetails.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { onMount } from 'svelte';
+  export let gameId;
+  let game;
+  let score;
+  onMount(async () => {
+    const res = await fetch(`/api/games/${gameId}`);
+    game = await res.json();
+    const resScore = await fetch(`/api/games/${gameId}/score`);
+    score = await resScore.json();
+  });
+</script>
+
+{#if game}
+<h1>{game.title}</h1>
+<p>Score: {score}</p>
+<a href="/">Back to list</a>
+{/if}

--- a/svelte-frontend/src/pages/GameList.svelte
+++ b/svelte-frontend/src/pages/GameList.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { onMount } from 'svelte';
+  let games = [];
+  onMount(async () => {
+    const res = await fetch('/api/games');
+    games = await res.json();
+  });
+</script>
+
+<h1>Game List</h1>
+<ul>
+  {#each games as game}
+    <li><a href={'/game/' + game.id}>{game.title}</a></li>
+  {/each}
+</ul>


### PR DESCRIPTION
## Summary
- create `GamesController` with endpoints for list, details and score
- register controllers in API `Program.cs`
- add simple router to Svelte app and split into pages
- implement `GameList` and `GameDetails` Svelte pages

## Testing
- `npm install` and `npm run build` in `svelte-frontend`
- _Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies._

------
https://chatgpt.com/codex/tasks/task_e_683fbdd12a288321b2b69aad3021fc5c